### PR TITLE
Fix script order for Tailwind config

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,8 +1,8 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>North Byte IT</title>
-<script src="https://cdn.tailwindcss.com/3.4.16"></script>
 <script src="/js/tailwind.config.js"></script>
+<script src="https://cdn.tailwindcss.com/3.4.16"></script>
 <script src="/js/main.js"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary
- ensure Tailwind config loads before CDN in `_includes/head.html`

## Testing
- `bundle exec jekyll build` *(fails: bundler can't find jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_684d360eee1083319406809403b8b405